### PR TITLE
Adjust initial migration to contain editable=False for field created

### DIFF
--- a/django_price/migrations/0001_initial.py
+++ b/django_price/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=25)),
-                ('created', models.DateTimeField(default=datetime.datetime.now)),
+                ('created', models.DateTimeField(default=datetime.datetime.now, editable=False)),
                 ('modified', models.DateTimeField(auto_now=True)),
             ],
             options={


### PR DESCRIPTION
Otherwise a `makemigrations` will add a new migration that only contains that change. We don't need that additional migration as the `editable` keyword argument won't change the DB.

This propably only happens with Django 1.8 and not Django 1.7.
